### PR TITLE
Refactored Leaflet example

### DIFF
--- a/LeafletExample/.gitignore
+++ b/LeafletExample/.gitignore
@@ -1,0 +1,1 @@
+www/js/APIKeys.js

--- a/LeafletExample/config.xml
+++ b/LeafletExample/config.xml
@@ -38,7 +38,7 @@
         <icon height="58" src="www/img/ios/Icon-small@2x.png" width="58" />
         <icon height="87" src="www/img/ios/Icon-small@3x.png" width="87" />
     </platform>
-    <engine name="android" spec="~6.3.0" />
-    <plugin name="cordova-plugin-whitelist" spec="1" />
-    <plugin name="cordova-plugin-indooratlas" spec="https://github.com/IndoorAtlas/cordova-plugin.git" />
+    <engine name="android" spec="^6.3.0" />
+    <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
+    <plugin name="cordova-plugin-indooratlas" spec="git+https://github.com/IndoorAtlas/cordova-plugin.git" />
 </widget>

--- a/LeafletExample/www/index.html
+++ b/LeafletExample/www/index.html
@@ -40,29 +40,22 @@ under the License.
 		html, body {
 			height: 100%;
 			margin: 0;
+			padding: 0;
 		}
 		#map {
-			width: 600px;
-			height: 400px;
+			width: 100vw;
+			height: 100%;
 		}
 	</style>
-
-	<style>body { padding: 0; margin: 0; } #map { height: 100%; width: 100vw; }</style>
 </head>
 <body>
 
 <div id='map'></div>
 
-<div class="app">
-  <div id="deviceready" class="blink">
-    <p class="event listening">Connecting to Device</p>
-    <p class="event received">Device is Ready</p>
-  </div>
-</div>
-
 <script type="text/javascript" src="cordova.js"></script>
 <script type="text/javascript" src="js/APIKeys.js"></script>
 <script type="text/javascript" src="js/Leaflet.ImageOverlay.Rotated.js"></script>
+<script type="text/javascript" src="js/FloorPlanUtil.js"></script>
 <script type="text/javascript" src="js/index.js"></script>
 
 </body>

--- a/LeafletExample/www/js/APIKeys.js.example
+++ b/LeafletExample/www/js/APIKeys.js.example
@@ -4,6 +4,8 @@
  * https://github.com/IndoorAtlas/sdk-cordova-examples
  */
 
+// rename this file to APIKeys.js and insert your API keys
+
 // This can be left blank if you do not want to show Mapbox outdoor maps
 // underneath the floor plans. Otherwise get a token at https://www.mapbox.com/
 var MAPBOX_ACCESS_TOKEN = "";

--- a/LeafletExample/www/js/FloorPlanUtil.js
+++ b/LeafletExample/www/js/FloorPlanUtil.js
@@ -1,3 +1,27 @@
+/*
+* IndoorAtlas Cordova Plugin Examples
+* https://github.com/IndoorAtlas/cordova-plugin
+* https://github.com/IndoorAtlas/sdk-cordova-examples
+*/
+
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 // a generic async cache
 function PromiseCache() {
@@ -74,8 +98,10 @@ function FloorPlanView(map) {
 
   this.hide = function(id) {
     if (!visibleFloorPlans[id]) return;
-    layers[id].remove();
-    visibleFloorPlans[id] = false;
+    if (layers[id]) {
+      layers[id].remove();
+    }
+    delete visibleFloorPlans[id];
   };
 
   this.showAndHideOthers = function (id) {

--- a/LeafletExample/www/js/FloorPlanUtil.js
+++ b/LeafletExample/www/js/FloorPlanUtil.js
@@ -1,0 +1,102 @@
+
+// a generic async cache
+function PromiseCache() {
+  var pending = {};
+  var values = {};
+
+  this.get = function (key, promiseGetter) {
+    if (values[key]) {
+      return Promise.resolve(values[key]);
+    }
+    if (pending[key]) {
+      return pending[key];
+    }
+    pending[key] = promiseGetter(key).then(function (value) {
+      delete pending[key];
+      values[key] = value;
+      return value;
+    });
+    return pending[key];
+  };
+};
+
+// handles caching of floor plan metadata and fetching it from the IA Cloud
+function FloorPlanCache() {
+  var cache = new PromiseCache();
+
+  // returns a promise
+  this.get = function (id) {
+    return cache.get(id, function (id) {
+      return new Promise(function (resolve, reject) {
+        IndoorAtlas.fetchFloorPlanWithId(id, resolve, reject);
+      });
+    });
+  };
+}
+
+// can hide an show multiple floor plans on a map
+function FloorPlanView(map) {
+  var layers = {};
+  var visibleFloorPlans = {};
+  var cache = new FloorPlanCache();
+  var that = this;
+
+  function asLatLng(coords) {
+    return [coords[1], coords[0]];
+  }
+
+  function buildImageOverlay(floorPlan) {
+    return L.imageOverlay.rotated(floorPlan.url,
+      asLatLng(floorPlan.topLeft),
+      asLatLng(floorPlan.topRight),
+      asLatLng(floorPlan.bottomLeft));
+  }
+
+  this.show = function(id) {
+    if (visibleFloorPlans[id]) return;
+    visibleFloorPlans[id] = true;
+
+    if (layers[id]) {
+      layers[id].addTo(map);
+    } else {
+      cache.get(id).then(function (floorPlan) {
+        if (!layers[id]) {
+          layers[id] = buildImageOverlay(floorPlan);
+        }
+        if (visibleFloorPlans[id]) {
+          layers[id].addTo(map);
+        }
+      }).catch(function (error) {
+        that.onError(id, error);
+      });
+    }
+  };
+
+  this.hide = function(id) {
+    if (!visibleFloorPlans[id]) return;
+    layers[id].remove();
+    visibleFloorPlans[id] = false;
+  };
+
+  this.showAndHideOthers = function (id) {
+    var toRemove = [];
+    for (var fpId in visibleFloorPlans) {
+      if (fpId != id) toRemove.push(fpId);
+    }
+    this.show(id);
+    // remove after show to reduce blinking
+    toRemove.forEach(function (fpId) {
+      that.hide(fpId);
+    });
+  };
+
+  this.hideAll = function () {
+    for (var fpId in visibleFloorPlans) {
+      this.hide(fpId);
+    }
+  }
+
+  this.onError = function (id, error) {
+    alert("Failed to fetch floor plan with ID "+id+": "+JSON.stringify(error));
+  };
+}

--- a/LeafletExample/www/js/index.js
+++ b/LeafletExample/www/js/index.js
@@ -25,7 +25,9 @@
 
 function ExampleApp() {
 
-  var map = L.map('map').fitWorld();
+  var map = L.map('map', {
+    zoomControl: false
+  }).fitWorld();
 
   if (MAPBOX_ACCESS_TOKEN) {
     L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token=' + MAPBOX_ACCESS_TOKEN, {
@@ -38,11 +40,23 @@ function ExampleApp() {
     }).addTo(map);
   }
 
+  // fix Leaflet zooming bugs
+  var zoomOngoing = false;
+  map.on('zoomstart', function () {
+    zoomOngoing = true;
+  });
+  map.on('zoomend', function () {
+    zoomOngoing = false;
+  });
+
   var currentFloorPlanId = null;
   var floorPlanView = new FloorPlanView(map);
   var accuracyCircle = null;
 
   this.onLocationChanged = function(position) {
+    // updating graphics while zooming does not work in Leaflet
+    if (zoomOngoing) return;
+
     var center = [position.coords.latitude, position.coords.longitude];
 
     function setCircleProperties() {

--- a/LeafletExample/www/js/index.js
+++ b/LeafletExample/www/js/index.js
@@ -23,267 +23,141 @@
 * under the License.
 */
 
-var app = {
+function ExampleApp() {
+
+	var map = L.map('map').fitWorld();
+
+  if (MAPBOX_ACCESS_TOKEN) {
+  	L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token=' + MAPBOX_ACCESS_TOKEN, {
+  		maxZoom: 23,
+  		attribution: 'Map data &copy; OpenStreetMap contributors, ' +
+  			'CC-BY-SA, ' +
+  			'Imagery © Mapbox',
+  		id: 'mapbox.light',
+      detectRetina: true
+  	}).addTo(map);
+  }
+
+  var currentFloorPlanId = null;
+  var floorPlanView = new FloorPlanView(map);
+  var accuracyCircle = null;
+
+  this.onLocationChanged = function(position) {
+    var center = [position.coords.latitude, position.coords.longitude];
+
+    function setCircleProperties() {
+      accuracyCircle.setLatLng(center);
+      accuracyCircle.setRadius(position.coords.accuracy);
+    }
+
+    if (!accuracyCircle) {
+      // first location
+      accuracyCircle = L.circle([0,0], {radius: 1});
+      setCircleProperties();
+      accuracyCircle.addTo(map);
+
+      var ZOOM_LEVEL = 19;
+      map.setView(center, ZOOM_LEVEL);
+    } else {
+      setCircleProperties();
+    }
+  };
+
+  this.onEnterRegion = function(region) {
+    if (region.regionType == Region.TYPE_FLOORPLAN) {
+
+      currentFloorPlanId = region.regionId;
+      console.log("enter floor plan "+currentFloorPlanId);
+      floorPlanView.showAndHideOthers(currentFloorPlanId);
+
+    } else if (region.regionType == Region.TYPE_VENUE) {
+      console.log("enter venue "+region.regionId);
+    }
+  };
+
+  this.onExitRegion = function(region) {
+    if (region.regionType == Region.TYPE_FLOORPLAN) {
+      console.log("exit floor plan");
+      currentFloorPlanId = null;
+
+      setTimeout(function () {
+        // don't hide immediately if the callback is followed by
+        // another enter floor plan event
+        if (!currentFloorPlanId) {
+          floorPlanView.hideAll();
+        }
+      }, 100);
+    }
+  };
+}
+
+var cordovaAndIaController = {
+  watchId: null,
+  regionWatchId: null,
+
   // Application Constructor
   initialize: function() {
     this.bindEvents();
   },
-  // Bind Event Listeners
-  //
-  // Bind any events that are required on startup. Common events are:
-  // 'load', 'deviceready', 'offline', and 'online'.
+
+  // Bind Cordova Event Listeners
   bindEvents: function() {
-    document.addEventListener('deviceready', this.onDeviceReady, false);
+    document.addEventListener('deviceready', this.onDeviceReady.bind(this), false);
   },
+
   // deviceready Event Handler
-  //
-  // The scope of 'this' is the event. In order to call the 'receivedEvent'
-  // function, we must explicitly call 'app.receivedEvent(...);'
   onDeviceReady: function() {
-    app.receivedEvent('deviceready');
-    cordovaExample.configureIA();
+    this.configureIA();
   },
-  // Update DOM on a Received Event
-  receivedEvent: function(id) {
-    var parentElement = document.getElementById(id);
-    var listeningElement = parentElement.querySelector('.listening');
-    var receivedElement = parentElement.querySelector('.received');
 
-    listeningElement.setAttribute('style', 'display:none;');
-    receivedElement.setAttribute('style', 'display:block;');
-
-    console.log('Received Event: ' + id);
-  }
-};
-
-function CordovaExample() {
-
-  var map = null;
-  var self = this;
-
-  var watchId = null;
-  var regionWatchId = null;
-
-  var accuracyCircle = null;
-  var floorPlanManager = null;
-
-  // ---- public
-
-  // Configures IndoorAtlas SDK with API Key and Secret
-  // Set the API Keys in www/js/APIKeys.js
-  this.configureIA = function() {
+  // Configure IndoorAtlas SDK with API Key
+  configureIA: function() {
     var _config = {key : IA_API_KEY, secret : IA_API_SECRET};
-    IndoorAtlas.onStatusChanged(onStatusChanged, alert);
-    IndoorAtlas.initialize(IAServiceConfigured, IAServiceFailed, _config);
-    return false;
-  };
+    IndoorAtlas.onStatusChanged(this.onStatusChanged.bind(this), alert);
+    IndoorAtlas.initialize(
+      this.IAServiceConfigured.bind(this),
+      this.IAServiceFailed.bind(this), _config);
+  },
 
-  // ---- private
-
-  function onStatusChanged(status) {
+  onStatusChanged: function (status) {
     console.log("status changed: "+status.message);
     if (status.code === CurrentStatus.STATUS_OUT_OF_SERVICE) {
       alert("Unrecoverable error: "+status.message);
     }
-  }
+  },
 
-  function IAServiceFailed (result) {
+  IAServiceFailed: function (result) {
     // Try again to initialize the service
     console.warn("IAServiceFailed, trying again: "+JSON.stringify(result));
-    setTimeout(self.configureIA, 2*1000);
-  }
+    setTimeout(this.configureIA.bind(this), 2*1000);
+  },
 
-  function IAServiceConfigured(result) {
-    startPositioning();
-  }
+  IAServiceConfigured: function() {
+    console.log("IA configured");
+    this.startPositioning();
+  },
 
-  // Starts IA positioning
-  function startPositioning() {
-    if (watchId != null) {
-      IndoorAtlas.clearWatch(watchId);
+  startPositioning: function() {
+    console.log("starting positioning");
+
+    var onError = this.IAServiceFailed.bind(this);
+
+    // watch position
+    if (this.watchId != null) {
+      IndoorAtlas.clearWatch(this.watchId);
     }
-    watchId = IndoorAtlas.watchPosition(showLocation, IAServiceFailed);
-    startRegionWatch();
-  }
+    this.watchId = IndoorAtlas.watchPosition(
+      app.onLocationChanged.bind(app), onError);
 
-  // Displays the current location of the user
-  function showLocation(position) {
-    // Show a map centered at (position.coords.latitude, position.coords.longitude).
-    try {
-      var center = [position.coords.latitude, position.coords.longitude];
-
-      function setCircleProperties() {
-        accuracyCircle.setLatLng(center);
-        accuracyCircle.setRadius(position.coords.accuracy);
-      }
-
-      if (!accuracyCircle) {
-        // first location
-        accuracyCircle = L.circle([0,0], {radius: 1});
-        setCircleProperties();
-        accuracyCircle.addTo(map);
-
-        var ZOOM_LEVEL = 19;
-        map.setView(center, ZOOM_LEVEL);
-      } else {
-        setCircleProperties();
-      }
+    // watch region
+    if (this.regionWatchId != null) {
+      IndoorAtlas.clearRegionWatch(this.regionWatchId);
     }
-    catch(error) {alert(error)};
+    this.regionWatchId = IndoorAtlas.watchRegion(
+      app.onEnterRegion.bind(app),
+      app.onExitRegion.bind(app), onError);
   }
-
-  // Starts watching changes in region id
-  function startRegionWatch() {
-    if (regionWatchId != null) {
-      IndoorAtlas.clearRegionWatch(regionWatchId);
-    }
-    var onEnterRegion = function(region) {
-      if (region.regionType == Region.TYPE_FLOORPLAN) {
-        floorPlanManager.onEnterFloorPlan(region.regionId);
-      }
-    };
-    var onExitRegion = function(region) {
-      if (region.regionType == Region.TYPE_FLOORPLAN) {
-        floorPlanManager.onExitFloorPlan(region.regionId);
-      }
-    };
-    regionWatchId = IndoorAtlas.watchRegion(onEnterRegion, onExitRegion, IAServiceFailed);
-  }
-
-  // Stops watching for the changes in region id
-  function stopRegionWatch() {
-    IndoorAtlas.clearRegionWatch(regionWatchId);
-  }
-
-  // Initializes Leaflet map
-  function initializeMap() {
-
-  	map = L.map('map').fitWorld();
-
-    if (MAPBOX_ACCESS_TOKEN) {
-    	L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token=' + MAPBOX_ACCESS_TOKEN, {
-    		maxZoom: 23,
-    		attribution: 'Map data &copy; OpenStreetMap contributors, ' +
-    			'CC-BY-SA, ' +
-    			'Imagery © Mapbox',
-    		id: 'mapbox.light',
-        detectRetina: true
-    	}).addTo(map);
-    }
-
-    floorPlanManager = new FloorPlanManager(map);
-  }
-
-  // ---- init
-  initializeMap();
 };
 
-// can hide an show multiple floor plans on a map
-function FloorPlanView(map) {
-  var layers = {};
-  var visibleFloorPlans = {};
-
-  function asLatLng(coords) {
-    return [coords[1], coords[0]];
-  }
-
-  function buildImageOverlay(floorPlan) {
-    return L.imageOverlay.rotated(floorPlan.url,
-      asLatLng(floorPlan.topLeft),
-      asLatLng(floorPlan.topRight),
-      asLatLng(floorPlan.bottomLeft));
-  }
-
-  this.show = function(floorPlan) {
-    var id = floorPlan.id;
-    if (visibleFloorPlans[id]) return;
-
-    if (!layers[id]) {
-      layers[id] = buildImageOverlay(floorPlan);
-    }
-    layers[id].addTo(map);
-    visibleFloorPlans[id] = true;
-  }
-
-  this.hide = function(floorPlan) {
-    var id = floorPlan.id;
-    if (!visibleFloorPlans[id]) return;
-    layers[id].remove();
-    visibleFloorPlans[id] = false;
-  }
-}
-
-// handles caching of floor plan metadata and fetching it from the IA Cloud
-function FloorPlanCache() {
-  var metadata = {};
-
-  this.fetchById = function (id, callback) {
-    // download unless cached or pending
-    if (!metadata[id]) {
-      metadata[id] = "pending";
-      IndoorAtlas.fetchFloorPlanWithId(id, function (floorPlan) {
-        metadata[id] = floorPlan;
-        callback(floorPlan);
-      }, function (error) {
-        alert("Failed to fetch floor plan with ID "+id+": "+JSON.stringify(error));
-      });
-    }
-    else if (metadata[id] != "pending") {
-      callback(floorPlan);
-    }
-  };
-}
-
-// handles fetching of floor plan metadata from IA cloud & showing
-// a single floor plan
-function FloorPlanManager(map) {
-  var floorPlanView = new FloorPlanView(map);
-  var floorPlanCache = new FloorPlanCache();
-
-  // which floor plan should be visible
-  var currentFloorPlanId = null;
-
-  // which floor plan is visible
-  var visibleFloorPlan = null;
-
-  function showFloorPlan(floorPlan) {
-    var id = floorPlan.id;
-    floorPlanView.show(floorPlan);
-
-    // remove after adding the new floor plan to reduce blinking
-    if (visibleFloorPlan && visibleFloorPlan.id != id) {
-      floorPlanView.hide(visibleFloorPlan);
-    }
-    visibleFloorPlan = floorPlan;
-  };
-
-  this.hide = function() {
-    if (visibleFloorPlan) {
-      floorPlanView.hide(visibleFloorPlan);
-      visibleFloorPlan = null;
-    }
-  };
-
-  this.onExitFloorPlan = function(id) {
-    currentFloorPlanId = null;
-
-    setTimeout(function () {
-      // don't hide immediately if the callback is followed by
-      // another enter floor plan event
-      if (!currentFloorPlanId && visibleFloorPlan) {
-        this.hide();
-      }
-    }, 100);
-  };
-
-  this.onEnterFloorPlan = function(id) {
-    currentFloorPlanId = id;
-    floorPlanCache.fetchById(id, function (floorPlan) {
-      if (currentFloorPlanId != id) return;
-      showFloorPlan(floorPlan);
-    });
-  };
-}
-
-app.initialize();
-var cordovaExample = new CordovaExample();
+cordovaAndIaController.initialize();
+var app = new ExampleApp();

--- a/LeafletExample/www/js/index.js
+++ b/LeafletExample/www/js/index.js
@@ -25,17 +25,17 @@
 
 function ExampleApp() {
 
-	var map = L.map('map').fitWorld();
+  var map = L.map('map').fitWorld();
 
   if (MAPBOX_ACCESS_TOKEN) {
-  	L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token=' + MAPBOX_ACCESS_TOKEN, {
-  		maxZoom: 23,
-  		attribution: 'Map data &copy; OpenStreetMap contributors, ' +
-  			'CC-BY-SA, ' +
-  			'Imagery © Mapbox',
-  		id: 'mapbox.light',
+    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token=' + MAPBOX_ACCESS_TOKEN, {
+      maxZoom: 23,
+      attribution: 'Map data &copy; OpenStreetMap contributors, ' +
+        'CC-BY-SA, ' +
+        'Imagery © Mapbox',
+      id: 'mapbox.light',
       detectRetina: true
-  	}).addTo(map);
+    }).addTo(map);
   }
 
   var currentFloorPlanId = null;


### PR DESCRIPTION
 * API keys in .gitignore
 * reusable floor plan caching and display logic in `FloorPlanUtil.js`
 * rewrote `index.js` to look more like the new snippets: Cordova (and IA) boilerplate separated from app logic